### PR TITLE
Footer's extra bottom margin (Gap between body and footer) is removed.

### DIFF
--- a/dashboard.css
+++ b/dashboard.css
@@ -244,6 +244,10 @@ nav li a:hover{
     font-size: 18px;
 }
 
+.foot-names{
+    margin-bottom: 10px;
+}
+
 /* Key Frames */
 @media screen and (max-width: 768px) {
     .grid {


### PR DESCRIPTION
In previous code, there is not any styling code for .foot-names in dashboard.html, I think therefore it was showing some extra margin at bottom of footer. 

I have just added bit of styling there and pulled that .foot-names up by giving margin as 10px. It worked !

Also checked this for multiple screen sizes, there is no any bottom gap is there now.